### PR TITLE
Fixes documentation workflow

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -12,15 +12,24 @@ permissions:
   id-token: write
 
 jobs:
-  publish-documentation:
+  build-documentation:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Build html
         run: bin/gradle dokkaHtml --no-daemon --stacktrace
       - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v1.0.7
+        uses: actions/upload-pages-artifact@v3
         with:
           path: lib/build/dokka/html
+
+  publish-documentation:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build-documentation
+    runs-on: ubuntu-latest
+    steps:
       - name: Deploy GitHub Pages site
-        uses: actions/deploy-pages@v2.0.0
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Upgrades upload-pages-artifact to v3, and deploy-pages to v4.

The previous versions, v1.0.7 and v2.0.0, are both deprecated.