### PR TITLE
Updates CODEOWNERS to use GitHub team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @synesso @hugomd @cwmyers @aparkersquare @millyrowboat
+* @block/bitcoin-network-os


### PR DESCRIPTION
Updates CODEOWNERS to use a GitHub team, instead of individual collaborators. 

This will make it easier to add/remove internal collaborators in the future, without having to update `CODEOWNERS`.