### PR TITLE
Fixes parsing of uneven-byte length invoices

### DIFF
--- a/lib/api/lib.api
+++ b/lib/api/lib.api
@@ -33,9 +33,14 @@ public final class app/cash/lninvoice/Bech32DataKt {
 }
 
 public final class app/cash/lninvoice/BitReader {
+	public static final field Companion Lapp/cash/lninvoice/BitReader$Companion;
+	public static final field FIVE_BIT_MASK I
 	public fun <init> (Lokio/ByteString;)V
 	public final fun taggedFields ()Ljava/util/List;
 	public final fun timestamp (I)Ljava/time/Instant;
+}
+
+public final class app/cash/lninvoice/BitReader$Companion {
 }
 
 public final class app/cash/lninvoice/BitcoinAmount {
@@ -128,8 +133,8 @@ public final class app/cash/lninvoice/Network$Companion {
 
 public final class app/cash/lninvoice/PaymentRequest {
 	public static final field Companion Lapp/cash/lninvoice/PaymentRequest$Companion;
-	public fun <init> (Lapp/cash/lninvoice/Network;Ljava/time/Instant;Larrow/core/Option;Ljava/lang/String;Ljava/util/List;Lokio/ByteString;Lokio/ByteString;)V
-	public synthetic fun <init> (Lapp/cash/lninvoice/Network;Ljava/time/Instant;Larrow/core/Option;Ljava/lang/String;Ljava/util/List;Lokio/ByteString;Lokio/ByteString;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lapp/cash/lninvoice/Network;Ljava/time/Instant;Larrow/core/Option;Ljava/lang/String;Ljava/util/List;Lokio/ByteString;Lokio/ByteString;I)V
+	public synthetic fun <init> (Lapp/cash/lninvoice/Network;Ljava/time/Instant;Larrow/core/Option;Ljava/lang/String;Ljava/util/List;Lokio/ByteString;Lokio/ByteString;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lapp/cash/lninvoice/Network;
 	public final fun component2 ()Ljava/time/Instant;
 	public final fun component3 ()Larrow/core/Option;
@@ -137,8 +142,8 @@ public final class app/cash/lninvoice/PaymentRequest {
 	public final fun component5 ()Ljava/util/List;
 	public final fun component6 ()Lokio/ByteString;
 	public final fun component7 ()Lokio/ByteString;
-	public final fun copy (Lapp/cash/lninvoice/Network;Ljava/time/Instant;Larrow/core/Option;Ljava/lang/String;Ljava/util/List;Lokio/ByteString;Lokio/ByteString;)Lapp/cash/lninvoice/PaymentRequest;
-	public static synthetic fun copy$default (Lapp/cash/lninvoice/PaymentRequest;Lapp/cash/lninvoice/Network;Ljava/time/Instant;Larrow/core/Option;Ljava/lang/String;Ljava/util/List;Lokio/ByteString;Lokio/ByteString;ILjava/lang/Object;)Lapp/cash/lninvoice/PaymentRequest;
+	public final fun copy (Lapp/cash/lninvoice/Network;Ljava/time/Instant;Larrow/core/Option;Ljava/lang/String;Ljava/util/List;Lokio/ByteString;Lokio/ByteString;I)Lapp/cash/lninvoice/PaymentRequest;
+	public static synthetic fun copy$default (Lapp/cash/lninvoice/PaymentRequest;Lapp/cash/lninvoice/Network;Ljava/time/Instant;Larrow/core/Option;Ljava/lang/String;Ljava/util/List;Lokio/ByteString;Lokio/ByteString;IILjava/lang/Object;)Lapp/cash/lninvoice/PaymentRequest;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAmount ()Larrow/core/Option;
 	public final fun getDescription ()Larrow/core/Option;

--- a/lib/api/lib.api
+++ b/lib/api/lib.api
@@ -133,8 +133,8 @@ public final class app/cash/lninvoice/Network$Companion {
 
 public final class app/cash/lninvoice/PaymentRequest {
 	public static final field Companion Lapp/cash/lninvoice/PaymentRequest$Companion;
-	public fun <init> (Lapp/cash/lninvoice/Network;Ljava/time/Instant;Larrow/core/Option;Ljava/lang/String;Ljava/util/List;Lokio/ByteString;Lokio/ByteString;I)V
-	public synthetic fun <init> (Lapp/cash/lninvoice/Network;Ljava/time/Instant;Larrow/core/Option;Ljava/lang/String;Ljava/util/List;Lokio/ByteString;Lokio/ByteString;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lapp/cash/lninvoice/Network;Ljava/time/Instant;Larrow/core/Option;Ljava/lang/String;Ljava/util/List;Lokio/ByteString;Lokio/ByteString;)V
+	public synthetic fun <init> (Lapp/cash/lninvoice/Network;Ljava/time/Instant;Larrow/core/Option;Ljava/lang/String;Ljava/util/List;Lokio/ByteString;Lokio/ByteString;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lapp/cash/lninvoice/Network;
 	public final fun component2 ()Ljava/time/Instant;
 	public final fun component3 ()Larrow/core/Option;
@@ -142,8 +142,8 @@ public final class app/cash/lninvoice/PaymentRequest {
 	public final fun component5 ()Ljava/util/List;
 	public final fun component6 ()Lokio/ByteString;
 	public final fun component7 ()Lokio/ByteString;
-	public final fun copy (Lapp/cash/lninvoice/Network;Ljava/time/Instant;Larrow/core/Option;Ljava/lang/String;Ljava/util/List;Lokio/ByteString;Lokio/ByteString;I)Lapp/cash/lninvoice/PaymentRequest;
-	public static synthetic fun copy$default (Lapp/cash/lninvoice/PaymentRequest;Lapp/cash/lninvoice/Network;Ljava/time/Instant;Larrow/core/Option;Ljava/lang/String;Ljava/util/List;Lokio/ByteString;Lokio/ByteString;IILjava/lang/Object;)Lapp/cash/lninvoice/PaymentRequest;
+	public final fun copy (Lapp/cash/lninvoice/Network;Ljava/time/Instant;Larrow/core/Option;Ljava/lang/String;Ljava/util/List;Lokio/ByteString;Lokio/ByteString;)Lapp/cash/lninvoice/PaymentRequest;
+	public static synthetic fun copy$default (Lapp/cash/lninvoice/PaymentRequest;Lapp/cash/lninvoice/Network;Ljava/time/Instant;Larrow/core/Option;Ljava/lang/String;Ljava/util/List;Lokio/ByteString;Lokio/ByteString;ILjava/lang/Object;)Lapp/cash/lninvoice/PaymentRequest;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAmount ()Larrow/core/Option;
 	public final fun getDescription ()Larrow/core/Option;

--- a/lib/src/test/kotlin/app/cash/lninvoice/Invoices.kt
+++ b/lib/src/test/kotlin/app/cash/lninvoice/Invoices.kt
@@ -67,5 +67,12 @@ object Invoices {
     "qqqqqqqqqz599y53s3ujmcfjp5xrdap68qxymkqphwsexhmhr8wdz5usdzkzrse33chw6dlp3jhuhge9ley7j" +
     "2ayx36kawe7kmgg8sv5ugdyusdcqzn8z9x"
 
+  const val sampleWithUnevenBytes = "lnbc820n1p58jmqqdq4ga6kccmgw3jkx6pqf3xyxpp5gz4f05gw6k5sxypgqr" +
+    "ap9sp240lwtxe9tqzull4k9mwxuq2n2r5ssp598qjc2nx7xtjx6csk5j7cgh25q2ahwpurcv859dhwj8n2xw4" +
+    "3lds9qrsgqcqpcxqzfvrzjqg4aqpxjt4y6x7ncy45rcwue0r8zp90sflh6ufuvr4844aa36x4vgzqdryqqzqq" +
+    "qqsqqqqqqqqqqqqqq9grzjqdt5stcc3ms9jelz5eqg0mrzz45ckf30f2whjt6g2yqwhkdc9yy82z2lw5qqzxs" +
+    "qq5qqqqqqqqqqqqqq9gxhvk5ns8sdtjhp097v5mlv8dl7zuxuale70lct7r0vf6hkggf7pkps6qwgnuxatt5r" +
+    "tuzu8vjp3u3q02vuejj5ynalhdt2ydclc2rngpqtm9kn"
+
   val sampleDecoded: Bech32Data by lazy { sample.toBech32Data().orThrow() }
 }

--- a/lib/src/test/kotlin/app/cash/lninvoice/PaymentRequestTest.kt
+++ b/lib/src/test/kotlin/app/cash/lninvoice/PaymentRequestTest.kt
@@ -22,16 +22,19 @@ import app.cash.lninvoice.Invoices.sample
 import app.cash.lninvoice.Invoices.sampleDecoded
 import app.cash.lninvoice.Invoices.sampleWithDescriptionAndDescriptionHash
 import app.cash.lninvoice.Invoices.sampleWithPaymentHash
+import app.cash.lninvoice.Invoices.sampleWithUnevenBytes
 import app.cash.lninvoice.Invoices.signatureOverflowTest
 import io.kotest.assertions.arrow.core.shouldBeLeft
 import io.kotest.assertions.arrow.core.shouldBeNone
 import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.assertions.arrow.core.shouldBeSome
+import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.startWith
 import io.kotest.matchers.throwable.haveCauseOfType
 import io.kotest.matchers.throwable.haveMessage
@@ -40,7 +43,6 @@ import okio.ByteString.Companion.toByteString
 import java.time.Instant
 
 class PaymentRequestTest : StringSpec({
-
   "a valid invoice should be parsed" {
     PaymentRequest.parse(sample).shouldBeRight().should { invoice ->
       invoice.network shouldBe Network.MAIN
@@ -63,12 +65,15 @@ class PaymentRequestTest : StringSpec({
         ),
         TaggedField(5, 20, "1000000000000000000000000000000001001000".decodeHex())
       )
-      invoice.signature shouldBe (
-        "1a1e080419110517090811020d07030818070f16110a0b0c040506160a061c130e1b141f021906130c01061" +
-          "a090d1e1e191307001d00150a150d06080b141a181d080a0d010b111405161110100417190b160b160100170a1512001312040e1a1" +
-          "c000d0f07100801"
-        ).decodeHex()
+      invoice.signature shouldBe ("d7904cc4b74a22269c68c1df68a96c214d651b9376e9f164d3604da4b7deccce0e82aaab4c85d358ea14d0ae342da30812f95d976082eaac813911dae01af3c1").decodeHex()
     }
+  }
+
+  "a valid invoice with uneven bytes" {
+    val invoice = PaymentRequest.parse(sampleWithUnevenBytes).shouldBeRight()
+    invoice.signature.hex().shouldBe("35d96a4e0783572b85e5f329bfb0edff85c373bfcf9ffc2fc37b13abd9084f8360c3407227c3756ba0d7c170ec9063c881ea6733295093efeed5a88dc7f0a1cd")
+    invoice.paymentHash.shouldBe("40aa97d10ed5a903102800fa12c02aabfee59b255805cffeb62edc6e015350e9")
+    invoice.payeeNodePublicKey.hex().shouldBe("02372c5d8559e4c0d3943b0e86360207491cb8ac669b7def06427860e566771828")
   }
 
   "parsing succeeds for testnet" {

--- a/lib/src/test/kotlin/app/cash/lninvoice/PaymentRequestTest.kt
+++ b/lib/src/test/kotlin/app/cash/lninvoice/PaymentRequestTest.kt
@@ -28,7 +28,6 @@ import io.kotest.assertions.arrow.core.shouldBeLeft
 import io.kotest.assertions.arrow.core.shouldBeNone
 import io.kotest.assertions.arrow.core.shouldBeRight
 import io.kotest.assertions.arrow.core.shouldBeSome
-import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldContainExactly
@@ -40,6 +39,7 @@ import io.kotest.matchers.throwable.haveCauseOfType
 import io.kotest.matchers.throwable.haveMessage
 import okio.ByteString.Companion.decodeHex
 import okio.ByteString.Companion.toByteString
+import java.security.MessageDigest
 import java.time.Instant
 
 class PaymentRequestTest : StringSpec({
@@ -65,13 +65,13 @@ class PaymentRequestTest : StringSpec({
         ),
         TaggedField(5, 20, "1000000000000000000000000000000001001000".decodeHex())
       )
-      invoice.signature shouldBe ("d7904cc4b74a22269c68c1df68a96c214d651b9376e9f164d3604da4b7deccce0e82aaab4c85d358ea14d0ae342da30812f95d976082eaac813911dae01af3c1").decodeHex()
+      invoice.signature shouldBe ("d7904cc4b74a22269c68c1df68a96c214d651b9376e9f164d3604da4b7deccce0e82aaab4c85d358ea14d0ae342da30812f95d976082eaac813911dae01af3c101").decodeHex()
     }
   }
 
   "a valid invoice with uneven bytes" {
     val invoice = PaymentRequest.parse(sampleWithUnevenBytes).shouldBeRight()
-    invoice.signature.hex().shouldBe("35d96a4e0783572b85e5f329bfb0edff85c373bfcf9ffc2fc37b13abd9084f8360c3407227c3756ba0d7c170ec9063c881ea6733295093efeed5a88dc7f0a1cd")
+    invoice.signature.hex().shouldBe("35d96a4e0783572b85e5f329bfb0edff85c373bfcf9ffc2fc37b13abd9084f8360c3407227c3756ba0d7c170ec9063c881ea6733295093efeed5a88dc7f0a1cd01")
     invoice.paymentHash.shouldBe("40aa97d10ed5a903102800fa12c02aabfee59b255805cffeb62edc6e015350e9")
     invoice.payeeNodePublicKey.hex().shouldBe("02372c5d8559e4c0d3943b0e86360207491cb8ac669b7def06427860e566771828")
   }


### PR DESCRIPTION
The old byte string reader has a bug when reading data whose length is not a factor of 5.

For example, reading 7 bits, given two 5 bit bytes:
```
11111 00000
```

The existing implementation performs the following:
1. Read 7 bits: `1111100`
2. Skip final padding, so the final result is only 7 bits
3. Apply `Integer.parseInt("1111100")`, which _does not pad_, so the final result is off by 1 bit.

This results in an incorrect hexadecimal value of `7C`.

The new version in this patch accounts for this missing bit by padding the return value:
1. Read 7 bits: `1111100`
2. Pad: `11111000`
3. Apply `Integer.parseInt("11111000")`, so the value is no longer off by 1 bit.

This results in a correct hexadecimal value of `F8`.

This bug results in:
- Failure to retrieve the correct signature when parsing an invoice
- Failure to derive the correct public key from the signature, because the signature bits are incorrect

### Changes
- Fixes failure to pad end of byte string when there are an uneven
  number of bits to process
- Signatures now include the ECDSA recovery ID
- By fixing padding/bit misalignment bugs, the public key can be correctly derived from the signature