### PR TITLE
Publish new versions when a tag is pushed

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -1,6 +1,9 @@
 name: Publish a release
 
-on: workflow_dispatch
+on:
+  push:
+    tags:
+      - 'v*'
 
 env:
   TERM: dumb


### PR DESCRIPTION
Follows [kfsm](https://github.com/block/kfsm/), publishing on tag rather than
via manual workflow dispatch.
