### PR TITLE
Sets fetch depth in release workflow

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Check if tag is on main branch
         id: check-branch


### PR DESCRIPTION
This is necessary for the check-branch step to succeed.

Setting fetch-depth to zero ensures `actions/checkout` will pull the entire git history, so `check-branch` will succeed.