### PR TITLE
 Reject invoices with unknown required feature bits

### DIFF
--- a/lib/src/main/kotlin/app/cash/lninvoice/BitReader.kt
+++ b/lib/src/main/kotlin/app/cash/lninvoice/BitReader.kt
@@ -90,12 +90,18 @@ class BitReader(
     return byteString(bits - bits % 8).string(Charsets.UTF_8)
   }
 
-  /** Parse a number of `bytes` bytes and returns a set of ints indicating which bits in that number are set */
-  internal fun bits(bytes: Int): Set<Int> {
-    val bi = BigInteger.valueOf(long(bytes))
-    return (0..bi.bitLength()).fold(emptySet()) { acc, i ->
-      if (bi.testBit(i)) acc + i else acc
+  /**
+   * Reads [wordCount] 5-bit words, combines them into a single number (MSB first),
+   * and returns the set of bit positions that are set.
+   *
+   * For example, words [16, 8, 0] combine to binary 10000_01000_00000,
+   * which has bits 8 and 14 set (var_onion_optin + payment_secret).
+   */
+  internal fun bits(wordCount: Int): Set<Int> {
+    val value = bytes(wordCount).toByteArray().fold(BigInteger.ZERO) { acc, word ->
+      acc.shiftLeft(5).add(BigInteger.valueOf(word.toLong() and 0x1FL))
     }
+    return (0..value.bitLength()).filter { value.testBit(it) }.toSet()
   }
 
   companion object {

--- a/lib/src/main/kotlin/app/cash/lninvoice/PaymentRequest.kt
+++ b/lib/src/main/kotlin/app/cash/lninvoice/PaymentRequest.kt
@@ -20,6 +20,7 @@ import app.cash.lninvoice.FieldTags.DESCRIPTION
 import app.cash.lninvoice.FieldTags.DESCRIPTION_HASH
 import app.cash.lninvoice.FieldTags.EXPIRY
 import app.cash.lninvoice.FieldTags.EXTRA_ROUTING_INFO
+import app.cash.lninvoice.FieldTags.FEATURE_BITS
 import app.cash.lninvoice.FieldTags.PAYMENT_HASH
 import app.cash.quiver.extensions.orThrow
 import app.cash.quiver.extensions.toEither
@@ -107,6 +108,14 @@ data class PaymentRequest(
   companion object {
 
     private const val SIGNATURE_BYTE_SIZE = 104
+    private val KNOWN_INVOICE_FEATURE_BITS: Set<Int> = setOf(
+      8, 9,   // var_onion_optin
+      14, 15, // payment_secret
+      16, 17, // basic_mpp
+      24, 25, // option_route_blinding
+      36, 37, // option_attribution_data
+      48, 49, // option_payment_metadata
+    )
     private val HrpRegex = Regex("ln([a-z]+)(([0-9]*)([munp])?)?(.*)")
 
     /** Parse an encoded invoice into a PaymentRequest. */
@@ -197,13 +206,28 @@ data class PaymentRequest(
 
     private fun validateTaggedFields(
       taggedFields: List<TaggedField>,
-      strict: Boolean
+      strict: Boolean,
     ): Either<InvalidInvoice, List<TaggedField>> {
       val unknown: Set<Int> by lazy { taggedFields.map { it.tag }.toSet().minus(FieldTags.validTags().toSet()) }
       return if (strict && unknown.isNotEmpty()) {
         InvalidInvoice("Tagged field has unknown tag(s) [${unknown.joinToString(",")}]").left()
       } else {
-        taggedFields.right()
+        validateFeatureBits(taggedFields).map { taggedFields }
+      }
+    }
+
+    private fun validateFeatureBits(
+      taggedFields: List<TaggedField>,
+    ): Either<InvalidInvoice, Unit> {
+      val featureField = taggedFields.find { it.tag == FEATURE_BITS.tag } ?: return Unit.right()
+      val setBits = BitReader(featureField.data).bits(featureField.size)
+      val unknownRequired = setBits.filter { it % 2 == 0 && it !in KNOWN_INVOICE_FEATURE_BITS }
+      return if (unknownRequired.isNotEmpty()) {
+        InvalidInvoice(
+          "Invoice requires unknown feature(s) [${unknownRequired.sorted().joinToString(",")}]"
+        ).left()
+      } else {
+        Unit.right()
       }
     }
 

--- a/lib/src/test/kotlin/app/cash/lninvoice/BitReaderTest.kt
+++ b/lib/src/test/kotlin/app/cash/lninvoice/BitReaderTest.kt
@@ -74,6 +74,19 @@ class BitReaderTest : StringSpec({
     reader.byteString(24).string(Charsets.UTF_8) shouldBe "123"
   }
 
+  "bits parses small word counts" {
+    // 3 words: [16, 8, 0] -> binary 10000_01000_00000 -> bits 8 and 14 set
+    val data = byteArrayOf(16, 8, 0).toByteString()
+    BitReader(data).bits(3) shouldBe setOf(8, 14)
+  }
+
+  "bits handles word counts exceeding 64 bits" {
+    // 14 words (70 bits) with bit 65 set: word 0 = 1 (bit 65), rest zeros
+    val words = ByteArray(14)
+    words[0] = 1 // sets bit ((14 - 1) * 5) = bit 65
+    BitReader(words.toByteString()).bits(14) shouldBe setOf(65)
+  }
+
   "testing off-by-one bit padding when reading uneven bits" {
     // Given two 5-bit bytes: 11111 00000
     // Combine them:  1111100000

--- a/lib/src/test/kotlin/app/cash/lninvoice/Invoices.kt
+++ b/lib/src/test/kotlin/app/cash/lninvoice/Invoices.kt
@@ -17,8 +17,12 @@
 package app.cash.lninvoice
 
 import app.cash.quiver.extensions.orThrow
+import okio.ByteString.Companion.toByteString
 
 object Invoices {
+
+  private const val SAMPLE_FEATURE_FIELD_WORD_COUNT = 20
+  private const val SAMPLE_FEATURE_FIELD_DATA_START = 143
 
   const val sample = "lnbc25m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq" +
     "5vdhkven9v5sxyetpdeessp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9q5sqqqqqq" +
@@ -90,4 +94,25 @@ object Invoices {
 
 
   val sampleDecoded: Bech32Data by lazy { sample.toBech32Data().orThrow() }
+
+  /**
+   * Derived from [sample] with feature bit 50 set (an unknown required/even feature).
+   */
+  val sampleWithUnknownRequiredFeature: String by lazy {
+    sampleWithAdditionalFeatureBits(50)
+  }
+
+  val sampleWithKnownRequiredInvoiceFeature: String by lazy {
+    sampleWithAdditionalFeatureBits(36)
+  }
+
+  private fun sampleWithAdditionalFeatureBits(vararg bits: Int): String {
+    val payload = sampleDecoded.payload.toByteArray().clone()
+    bits.forEach { bit ->
+      require(bit in 0 until SAMPLE_FEATURE_FIELD_WORD_COUNT * 5) { "feature bit out of range: $bit" }
+      val wordIndex = SAMPLE_FEATURE_FIELD_DATA_START + SAMPLE_FEATURE_FIELD_WORD_COUNT - 1 - (bit / 5)
+      payload[wordIndex] = (payload[wordIndex].toInt() or (1 shl (bit % 5))).toByte()
+    }
+    return Bech32Data(Bech32Data.Companion.Encoding.BECH32, "lnbc25m", payload.toByteString()).encoded
+  }
 }

--- a/lib/src/test/kotlin/app/cash/lninvoice/TaggedFieldParsingTest.kt
+++ b/lib/src/test/kotlin/app/cash/lninvoice/TaggedFieldParsingTest.kt
@@ -63,4 +63,19 @@ class TaggedFieldParsingTest : StringSpec({
     PaymentRequest.parse(encoded = Invoices.sampleWithUnknownTags, strict = true)
       .shouldBeLeft().message shouldBe "Tagged field has unknown tag(s) [10]"
   }
+
+  "an invoice with only known optional features should parse in strict mode" {
+    PaymentRequest.parse(encoded = Invoices.sample, strict = true)
+      .shouldBeRight()
+  }
+
+  "an invoice with unknown required features should not parse" {
+    PaymentRequest.parse(encoded = Invoices.sampleWithUnknownRequiredFeature)
+      .shouldBeLeft().message shouldBe "Invoice requires unknown feature(s) [50]"
+  }
+
+  "an invoice with known required invoice features should parse" {
+    PaymentRequest.parse(encoded = Invoices.sampleWithKnownRequiredInvoiceFeature)
+      .shouldBeRight()
+  }
 })


### PR DESCRIPTION
`ln-invoice` parses BOLT-11 feature bits but never validates their values. This change validates feature bits at parse time so callers get a clear error (e.g. "Invoice requires unknown feature(s) [50]") before the invoice gets actually processed.

**what's changed?**: 
- Per BOLT-11, a reader MUST NOT attempt payment if the invoice contains unknown required (even) feature bits. This is now enforced unconditionally during `parse()`.
- Fixes a `BitReader.bits()` overflow where feature vectors larger than 64 bits were silently truncated due
  to use of Long instead of BigInteger.