### PR TITLE
Fix broken shields.io badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Parse Bitcoin Lightning Network invoices (payment requests) in Kotlin. This library implements decoding of invoices as per
 [BOLT-11: # Invoice Protocol for Lightning Payments](https://github.com/lightning/bolts/blob/master/11-payment-encoding.md#bolt-11-invoice-protocol-for-lightning-payments)
 
-[<img src="https://img.shields.io/nexus/r/app.cash.lninvoice/ln-invoice.svg?label=latest%20release&server=https%3A%2F%2Foss.sonatype.org"/>](https://central.sonatype.com/namespace/app.cash.lninvoice)
+[<img src="https://img.shields.io/maven-central/v/app.cash.lninvoice/ln-invoice.svg?label=latest%20release"/>](https://central.sonatype.com/namespace/app.cash.lninvoice)
 
 ## Getting Started
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=app.cash.lninvoice
-VERSION_NAME=0.0.5
+VERSION_NAME=0.0.6-SNAPSHOT
 POM_URL=https://github.com/cashapp/ln-invoice/
 POM_SCM_URL=https://github.com/cashapp/ln-invoice/
 POM_SCM_CONNECTION=scm:git:git://github.com/cashapp/ln-invoice.git


### PR DESCRIPTION
The shields.io badge was rendering as "artifact not found" because it used the deprecated `nexus/r` endpoint pointing at `oss.sonatype.org`, which no longer serves artifact metadata.

Switched to the `maven-central/v` endpoint, which shields.io supports natively.